### PR TITLE
fix to find the translations

### DIFF
--- a/PokemonGo.RocketAPI.Console/Translation/TranslationHandler.cs
+++ b/PokemonGo.RocketAPI.Console/Translation/TranslationHandler.cs
@@ -18,7 +18,7 @@ namespace PokemonGo.RocketAPI.Console.Translation
 
         public static void init()
         {
-            foreach(String file in System.IO.Directory.GetFiles("translations"))
+            foreach(String file in System.IO.Directory.GetFiles("../../../translations"))
             {
                 if (file.EndsWith(".json"))
                 {


### PR DESCRIPTION
alternative move the translations to \PokemonGo.RocketAPI.Console\Translation\translations