### PR TITLE
Fix loading of settings if german pokemon names are used

### DIFF
--- a/PokemonGo.RocketAPI.Console/GUI.cs
+++ b/PokemonGo.RocketAPI.Console/GUI.cs
@@ -285,11 +285,7 @@ namespace PokemonGo.RocketAPI.Console
                 string[] lines = System.IO.File.ReadAllLines(@Program.keep);
                 foreach (string line in lines)
                 {
-                    if (line != "")
-                        if (checkBox8.Checked)
-                            checkedListBox1.SetItemChecked(pokeIDS[gerEng[line]] - 1, true);
-                        else
-                            checkedListBox1.SetItemChecked(pokeIDS[line] - 1, true);
+                    SetCheckboxChecked(checkedListBox1, line, true);
                 }
             }
 
@@ -298,11 +294,7 @@ namespace PokemonGo.RocketAPI.Console
                 string[] lines = System.IO.File.ReadAllLines(@Program.ignore);
                 foreach (string line in lines)
                 {
-                    if (line != "")
-                        if (checkBox8.Checked)
-                            checkedListBox2.SetItemChecked(pokeIDS[gerEng[line]] - 1, true);
-                        else
-                            checkedListBox2.SetItemChecked(pokeIDS[line] - 1, true);
+                    SetCheckboxChecked(checkedListBox2, line, true);
                 }
             }
 
@@ -328,14 +320,22 @@ namespace PokemonGo.RocketAPI.Console
                 string[] lines = System.IO.File.ReadAllLines(@Program.evolve);
                 foreach (string line in lines)
                 {
-                    if (line != "")
-                        if (checkBox8.Checked)
-                            checkedListBox3.SetItemChecked(evolveIDS[gerEng[line]] - 1, true);
-                        else
-                            checkedListBox3.SetItemChecked(evolveIDS[line] - 1, true);
+                    SetCheckboxChecked(checkedListBox3, line, true);
                 }
             }
 
+        }
+
+        private static void SetCheckboxChecked(CheckedListBox listBox, string value, bool checkState)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                int index = listBox.Items.IndexOf(value);
+                if (index > -1)
+                {
+                    listBox.SetItemChecked(index, checkState);
+                }
+            }         
         }
 
         private void textBox3_KeyPress(object sender, KeyPressEventArgs e)


### PR DESCRIPTION
The issue here is that items in the pokemon lists are not sorted during loading the config. Therefore the indices won't match and wrong pokemon are checked in the list.

This is just a quick fix, but the overall settings process should be overhauled.