### PR TITLE
Update tr.json

### DIFF
--- a/translations/tr.json
+++ b/translations/tr.json
@@ -30,7 +30,7 @@
 "pokemonNotToTransfer":"Transfer edilmeyecek",
 "selectAll":"Hepsini Sec",
 "pokemonNotToCatch":"Yakalanmasini istemedigimiz",
-"pokemonNotToEvolve":"Evolve edilecekler",
+"pokemonNotToEvolve":"Evolve edilmeyecekler",
 "saveConfig":"Ayarlari Kaydet / Botu Baslat",
 "otherSettings":"Diger Ayarlar",
 "useLuckyeggAtEvolve":"Evolve ederken LuckyEgg Bas",


### PR DESCRIPTION
Tr translation for "pokemonNotToEvolve" was a positive expression meaning "pokemon to evolve" (Corrected to negative)