### PR TITLE
IV and CP Check moved to TransferDuplicatePokemon and improved

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using PokemonGo.RocketAPI.GeneratedCode;
@@ -197,7 +197,7 @@ namespace PokemonGo.RocketAPI.Logic
                     }
                     if (orderByIv)
                     {
-                        results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key && PokemonInfo.CalculatePokemonPerfection(x) <= _client.getSettingHandle().ivmaxpercent)
+                        results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
                             .ThenBy(n => n.StaminaMax)
                             .Skip(amountToSkip)
@@ -206,7 +206,7 @@ namespace PokemonGo.RocketAPI.Logic
                     }
                     else
                     {
-                        results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key && PokemonInfo.CalculatePokemonPerfection(x) <= _client.getSettingHandle().ivmaxpercent)
+                        results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(x => x.Cp)
                             .ThenBy(n => n.StaminaMax)
                             .Skip(amountToSkip)
@@ -222,8 +222,8 @@ namespace PokemonGo.RocketAPI.Logic
             {
                 return pokemonList
                     .GroupBy(p => p.PokemonId)
-                    .Where(x => x.Count() > 1)
-                    .SelectMany(p => p.Where(x => x.Favorite == 0 && PokemonInfo.CalculatePokemonPerfection(x) <= _client.getSettingHandle().ivmaxpercent)
+                    .Where(x => x.Count() > 0)
+                    .SelectMany(p => p.Where(x => x.Favorite == 0)
                     .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
                     .ThenBy(n => n.StaminaMax)
                     .Skip(_client.getSettingHandle().HoldMaxDoublePokemons)
@@ -234,8 +234,8 @@ namespace PokemonGo.RocketAPI.Logic
             {
                 return pokemonList
                     .GroupBy(p => p.PokemonId)
-                    .Where(x => x.Count() > 1)
-                    .SelectMany(p => p.Where(x => x.Favorite == 0 && PokemonInfo.CalculatePokemonPerfection(x) <= _client.getSettingHandle().ivmaxpercent)
+                    .Where(x => x.Count() > 0)
+                    .SelectMany(p => p.Where(x => x.Favorite == 0)
                     .OrderByDescending(x => x.Cp)
                     .ThenBy(n => n.StaminaMax)
                     .Skip(_client.getSettingHandle().HoldMaxDoublePokemons)

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -181,7 +181,7 @@ namespace PokemonGo.RocketAPI.Logic
 
         //    public bool ptc_online; //Online oder nicht?
         //    public double ptc_response; //Wie lange PTC zum responden braucht
-        //    public double ptc_idle; //Wie lange ptc schon läuft
+        //    public double ptc_idle; //Wie lange ptc schon lÃ¤uft
         //    public double ptc_uptime_hour; //Prozent von PTC uptime letzte stunde
         //    public double ptc_uptime_day; //Prozent von PTC uptime letzten tag
         //}
@@ -689,7 +689,7 @@ namespace PokemonGo.RocketAPI.Logic
                 {
                     if (!_clientSettings.pokemonsToHold.Contains(duplicatePokemon.PokemonId))
                     {
-                        if (duplicatePokemon.Cp > _clientSettings.DontTransferWithCPOver)
+                        if (duplicatePokemon.Cp >= _clientSettings.DontTransferWithCPOver || duplicatePokemon.CalculateIV() >= _client.getSettingHandle().ivmaxpercent)
                         {
                             continue;
                         }


### PR DESCRIPTION
- we won't transfer anything with the wrong CV or IV any more, both checked at the same place now
- the amountToSkip is included with the amount of IV's and CP's over the set values
- amountToSkip can now be set to 0!