### PR TITLE
"New Pokémon"-Color

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -597,7 +597,7 @@ namespace PokemonGo.RocketAPI.Logic
 
                         if (caughtPokemonResponse.CaptureAward.Xp.Sum() >= 500)
                         {
-                            Logger.ColoredConsoleWrite(ConsoleColor.Red,
+                            Logger.ColoredConsoleWrite(ConsoleColor.DarkMagenta,
                                 $"Caught New {StringUtils.getPokemonNameByLanguage(_clientSettings, pokemon.PokemonId)} CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} IV {PokemonInfo.CalculatePokemonPerfection(encounterPokemonResponse.WildPokemon.PokemonData).ToString("0.00")}% using {bestPokeball} got {caughtPokemonResponse.CaptureAward.Xp.Sum()} XP.");
                         }
                         else


### PR DESCRIPTION
Meinungssache: 
Wenn man bei allen Sachen ne komplett andere Farbe nimmt, dann kommt mir die Bot-Konsole langsam einfach nur noch wie ein großer Regenbogen vor. ô.ô
Wie wär's wenn wir dann die neuen Pokédex-Pokémon einfach auch in diesem Magenta lassen? Vielleicht sollte man die Farben allgemein mal ein bisschen überarbeiten. Wie gesagt: So langsam trennt das keine Informationen mehr sondern macht alles nur viel zu bunt. :D