### PR TITLE
fix: set preference for smaller eggs when down to last incubator

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -1984,6 +1984,12 @@ namespace PokemonGo.RocketAPI.Logic
                         var egg = (incubator.ItemId == ItemId.ItemIncubatorBasicUnlimited && incubators.Count > 1)
                             ? unusedEggs.FirstOrDefault()
                             : unusedEggs.LastOrDefault();
+                        
+                        // When you're down to your last incubator, prefer 2km then 10km then 5km so you
+                        // can clean out smaller eggs first.
+                        if(incubator.ItemId == ItemId.ItemIncubatorBasicUnlimited && incubators.Count == 1 && egg.EggKmWalkedTarget < 10) {
+                            egg = unusedEggs.FirstOrDefault();
+                        }
 
                         if (egg == null)
                             continue;


### PR DESCRIPTION
This allows you to get rid of smaller eggs (making room for more eggs faster) when you have only the last incubator left. The order becomes: 2km, 10km, 5km when you're down to only the unlimited incubator.